### PR TITLE
Updated URL_MATCH regex so queries and hashes are excluded.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ var path = require('path');
 var util = require('util');
 
 var PLUGIN_NAME = 'css-asset-rebaser';
-var URL_MATCH = /(url\(\s*['"]?)([^"')]+)(["']?\s*\))/;
+var URL_MATCH = /(url\(\s*['"]?)([^?#"')]+)(\??#[^"')]+)?(["']?\s*\))/;
 var URLS_MATCH = new RegExp(URL_MATCH.source, 'g');
 
 function filterDeclarations(ast, filePath) {


### PR DESCRIPTION
The file path which is created from `originalUrl` should not contain any query parameters or hashes to prevent `fs` copy errors.
E.g. the package `roboto-fontface` uses the following imports:

``` css
@font-face {
    font-family: 'Roboto';
    src: url('../../fonts/roboto/Roboto-Thin.eot');
    src: local('Roboto Thin'), local('Roboto-Thin'), url('../../fonts/roboto/Roboto-Thin.eot?#iefix') format('embedded-opentype'), url('../../fonts/roboto/Roboto-Thin.woff2') format('woff2'), url('../../fonts/roboto/Roboto-Thin.woff') format('woff'), url('../../fonts/roboto/Roboto-Thin.ttf') format('truetype'), url('../../fonts/roboto/Roboto-Thin.svg#Roboto') format('svg');
    font-weight: 100;
    font-style: normal;
}
```

Currently the plugin throws an error when copying files with query or has:

```
Error: Copying .\node_modules\roboto-fontface\fonts\roboto\Roboto-Thin.eot?#iefix failed: ENOENT: no such file or directory
```

This PR alters the URL_MATCH regex so queries and hashes are excluded from the url-group. The paths in the resulting css-file still have the needed queries and hashes.
